### PR TITLE
Add Room list component

### DIFF
--- a/src/components/RoomList.tsx
+++ b/src/components/RoomList.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react";
+import { Button, Card, Group, Stack, Text, Title } from "@mantine/core";
+import { useGameContext } from "../hooks/GameProvider";
+
+interface AvailableRoom {
+  roomId: string;
+  clients: number;
+  maxClients: number;
+  metadata: Record<string, unknown>;
+}
+
+interface RoomListProps {
+  displayName: string;
+}
+
+export function RoomList({ displayName }: RoomListProps) {
+  const { joinRoom } = useGameContext();
+  const [rooms, setRooms] = useState<AvailableRoom[]>([]);
+
+  const fetchRooms = async () => {
+    try {
+      const wsUrl = import.meta.env.VITE_COLYSEUS_URL as string;
+      const httpUrl = wsUrl.replace(/^ws/, "http");
+      const response = await fetch(`${httpUrl.replace(/\/$/, "")}/available_rooms`);
+      if (response.ok) {
+        const data = await response.json();
+        setRooms(Array.isArray(data) ? data : []);
+      }
+    } catch (err) {
+      console.error("Failed to fetch rooms", err);
+    }
+  };
+
+  useEffect(() => {
+    fetchRooms();
+    const interval = setInterval(fetchRooms, 5000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const handleJoin = (roomId: string) => {
+    if (displayName.trim()) {
+      localStorage.setItem("displayName", displayName);
+      joinRoom(displayName, roomId);
+    }
+  };
+
+  return (
+    <Stack align="center" gap="sm" mt="lg">
+      <Title order={3}>Available Rooms</Title>
+      {rooms.map((room) => (
+        <Card key={room.roomId} withBorder w={300}>
+          <Group justify="space-between">
+            <Text fw={600}>{room.roomId}</Text>
+            <Text>
+              {room.clients}/{room.maxClients}
+            </Text>
+          </Group>
+          <Button mt="sm" fullWidth onClick={() => handleJoin(room.roomId)}>
+            Join Room
+          </Button>
+        </Card>
+      ))}
+      {rooms.length === 0 && <Text size="sm">No rooms available.</Text>}
+    </Stack>
+  );
+}

--- a/src/screens/LobbyScreen.tsx
+++ b/src/screens/LobbyScreen.tsx
@@ -2,6 +2,7 @@ import { Button, Divider, Group, Stack, TextInput, Title } from "@mantine/core";
 import { useState, useEffect } from "react";
 import { useGameContext } from "../hooks/GameProvider";
 import { useLocation } from "react-router-dom";
+import { RoomList } from "../components/RoomList";
 
 export default function LobbyScreen() {
   const { joinRoom, createRoom } = useGameContext();
@@ -64,6 +65,8 @@ export default function LobbyScreen() {
       <Divider label="or" labelPosition="center" w={inputGroupWidth} />
 
       <Button size="lg" color="blue" onClick={handleCreate}>Create New Room</Button>
+
+      <RoomList displayName={displayName} />
     </Stack>
   );
 }


### PR DESCRIPTION
## Summary
- show available rooms in the lobby
- fetch `/available_rooms` from the server

## Testing
- `npm run build` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685f4481d72c832c8cf727a86ea033b2