### PR TITLE
Add emoji send/receive support

### DIFF
--- a/src/components/EmojiReceiveArea.tsx
+++ b/src/components/EmojiReceiveArea.tsx
@@ -44,17 +44,7 @@ export default function EmojiReceiveArea() {
   /* subscribe / unsubscribe exactly once per room instance */
   useEffect(() => {
     if (!room) return;
-
     room.onMessage("player_emoji", handleIncoming);
-
-    return () => {
-      // Colyseus ≥ 0.15 has offMessage; fall back to onMessage(undefined) otherwise
-      if (typeof (room as any).offMessage === "function") {
-        (room as any).offMessage("player_emoji", handleIncoming);
-      } else {
-        room.onMessage("player_emoji", undefined as any);
-      }
-    };
   }, [room, handleIncoming]);
 
   return (

--- a/src/components/EmojiReceiveArea.tsx
+++ b/src/components/EmojiReceiveArea.tsx
@@ -1,0 +1,65 @@
+import { Box, Text } from "@mantine/core";
+import { AnimatePresence, motion } from "framer-motion";
+import { useEffect, useState } from "react";
+import { useGameContext } from "../hooks/GameProvider";
+
+const EMOJI_MAP: Record<string, string> = {
+  ANGRY: "😡",
+  PARTY: "🎉",
+  CONFUSED: "❓",
+  LOVE: "❤",
+};
+
+interface EmojiPayload {
+  from: string;
+  name: string;
+  emoji: string;
+  sentAt: number;
+}
+
+export default function EmojiReceiveArea() {
+  const { room } = useGameContext();
+  const [messages, setMessages] = useState<EmojiPayload[]>([]);
+
+  useEffect(() => {
+    if (!room) return;
+
+    const handler = (payload: EmojiPayload) => {
+      setMessages((msgs) => [...msgs, payload]);
+      setTimeout(() => {
+        setMessages((msgs) => msgs.filter((m) => m.sentAt !== payload.sentAt));
+      }, 2500);
+    };
+
+    room.onMessage("player_emoji", handler);
+    return () => {
+      // @ts-ignore remove listener if available
+      room.off?.("player_emoji", handler);
+    };
+  }, [room]);
+
+  return (
+    <Box style={{ position: "relative", width: "100%", height: "100%" }}>
+      <AnimatePresence>
+        {messages.map((msg) => (
+          <motion.div
+            key={msg.sentAt}
+            initial={{ y: -10, opacity: 1 }}
+            animate={{ y: 40, opacity: 0 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 2 }}
+            style={{
+              position: "absolute",
+              left: "50%",
+              transform: "translateX(-50%)",
+              fontSize: "1.5rem",
+              whiteSpace: "nowrap",
+            }}
+          >
+            <Text fw={700}>{msg.name}: {EMOJI_MAP[msg.emoji] ?? msg.emoji}</Text>
+          </motion.div>
+        ))}
+      </AnimatePresence>
+    </Box>
+  );
+}

--- a/src/components/EmojiSendPanel.tsx
+++ b/src/components/EmojiSendPanel.tsx
@@ -1,0 +1,29 @@
+import { SimpleGrid, Button } from "@mantine/core";
+import { useGameContext } from "../hooks/GameProvider";
+
+const EMOJIS: { label: string; symbol: string }[] = [
+  { label: "ANGRY", symbol: "😡" },
+  { label: "PARTY", symbol: "🎉" },
+  { label: "CONFUSED", symbol: "❓" },
+  { label: "LOVE", symbol: "❤" },
+];
+
+export default function EmojiSendPanel() {
+  const { sendEmoji } = useGameContext();
+
+  return (
+    <SimpleGrid cols={2} spacing="xs" w="100%">
+      {EMOJIS.map(({ label, symbol }) => (
+        <Button
+          key={label}
+          variant="outline"
+          size="md"
+          onClick={() => sendEmoji(label)}
+          style={{ fontSize: "1.5rem", padding: 4 }}
+        >
+          {symbol}
+        </Button>
+      ))}
+    </SimpleGrid>
+  );
+}

--- a/src/hooks/useGameRoom.tsx
+++ b/src/hooks/useGameRoom.tsx
@@ -246,6 +246,10 @@ export const useGameRoom = (client: Colyseus.Client) => {
     room?.send("give_up");
   }
 
+  const sendEmoji = (emoji: string) => {
+    room?.send("send_emoji", emoji);
+  };
+
   return {
     room,
     joinRoom,
@@ -279,7 +283,8 @@ export const useGameRoom = (client: Colyseus.Client) => {
     sendCancelInterest,
     sendFinishTaskAllocation,
     sendRestartGame,
-    sendGiveUp
+    sendGiveUp,
+    sendEmoji
   };
 };
 

--- a/src/screens/PlayerGridLayout.tsx
+++ b/src/screens/PlayerGridLayout.tsx
@@ -9,6 +9,8 @@ import { Card } from "../types";
 import { IconInfoCircle, IconArrowBackUp } from "@tabler/icons-react";
 import { InfoModal } from "../components/InfoModal";
 import { useDisclosure } from "@mantine/hooks";
+import EmojiSendPanel from "../components/EmojiSendPanel";
+import EmojiReceiveArea from "../components/EmojiReceiveArea";
 
 interface PlayerGridLayoutProps {
   gridTemplateAreas: string;
@@ -94,6 +96,11 @@ export default function PlayerGridLayout({ gridTemplateAreas, children, isMyTurn
       }}
       p="sm"
     >
+      {/* Emoji Receive Area */}
+      <Box style={{ gridArea: "emoji-receive" }}>
+        <EmojiReceiveArea />
+      </Box>
+
       {/* Other Players' Status */}
       {otherPlayers.map(({ player, gridArea }) => {
         const assignedTasks = tasks.filter(t => t.player === player.sessionId);
@@ -198,6 +205,8 @@ export default function PlayerGridLayout({ gridTemplateAreas, children, isMyTurn
           }}
         />
       </Box>
+      {/* Emoji Send Panel */}
+      <Box style={{ gridArea: "emoji-send" }}><EmojiSendPanel /></Box>
 
 
 


### PR DESCRIPTION
## Summary
- add `sendEmoji` helper in `useGameRoom`
- show send/receive emoji components in `PlayerGridLayout`
- implement `EmojiSendPanel` with simple 2x2 grid
- implement `EmojiReceiveArea` that displays floating emojis

## Testing
- `npm run build` *(fails: Cannot find module '@mantine/core')*

------
https://chatgpt.com/codex/tasks/task_e_686869200630832c990d04972019f8da