### PR TITLE
Add disconnect modal with reconnection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,37 +8,44 @@ import GameSetupScreen from "./screens/GameSetupScreen";
 import TaskPhaseScreen from "./screens/TaskPhaseScreen";
 import TrickPhaseScreen from "./screens/TrickPhaseScreen";
 import GameOverScreen from "./screens/GameOverScreen";
+import DisconnectModal from "./components/DisconnectModal";
 
 function AppContent() {
-  const { room, gameStage } = useGameContext();
+  const { room, gameStage, disconnectReason, connectionLogs, reconnect } = useGameContext();
   const isJoined = !!room;
 
+  let screen;
   if (!isJoined) {
-    return (
+    screen = (
       <Container>
         <LobbyScreen />
       </Container>
     );
-  }
-
-  if (gameStage === "not_started") {
-    return (
+  } else if (gameStage === "not_started") {
+    screen = (
       <Container>
         <GameSetupScreen />
       </Container>
     );
+  } else if (gameStage === "game_setup") {
+    screen = <TaskPhaseScreen />;
+  } else if (gameStage === "game_end") {
+    screen = <GameOverScreen />;
+  } else {
+    screen = <TrickPhaseScreen />;
   }
 
-  // Gameplay Phases
-  if (gameStage === "game_setup") {
-    return <TaskPhaseScreen />;
-  }
-
-  if (gameStage === "game_end") {
-    return <GameOverScreen />;
-  }
-  
-  return <TrickPhaseScreen />;
+  return (
+    <>
+      {screen}
+      <DisconnectModal
+        opened={!!disconnectReason}
+        reason={disconnectReason}
+        logs={connectionLogs}
+        onReconnect={reconnect}
+      />
+    </>
+  );
 }
 
 export default function App() {

--- a/src/components/DisconnectModal.tsx
+++ b/src/components/DisconnectModal.tsx
@@ -1,0 +1,22 @@
+import { Modal, Stack, Text, Button, Code } from '@mantine/core';
+
+interface DisconnectModalProps {
+  opened: boolean;
+  reason?: string | null;
+  logs: string[];
+  onReconnect: () => void;
+}
+
+export default function DisconnectModal({ opened, reason, logs, onReconnect }: DisconnectModalProps) {
+  return (
+    <Modal opened={opened} onClose={() => {}} title="Connection Lost" centered closeOnClickOutside={false} closeOnEscape={false}>
+      <Stack>
+        <Text c="red" fw={600}>Disconnected{reason ? `: ${reason}` : ''}</Text>
+        {logs.length > 0 && (
+          <Code block>{logs.join('\n')}</Code>
+        )}
+        <Button mt="sm" onClick={onReconnect}>Reconnect</Button>
+      </Stack>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Summary
- track connection logs and disconnection reasons
- show a modal when disconnected that lists logs and offers a reconnect button

## Testing
- `npm run build` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6868ddfd7ce8832cb808411796f34216