### PR TITLE
Add High Scores screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,9 @@ import GameSetupScreen from "./screens/GameSetupScreen";
 import TaskPhaseScreen from "./screens/TaskPhaseScreen";
 import TrickPhaseScreen from "./screens/TrickPhaseScreen";
 import GameOverScreen from "./screens/GameOverScreen";
+import HighScoresScreen from "./screens/HighScoresScreen";
 import DisconnectModal from "./components/DisconnectModal";
+import { Routes, Route } from "react-router-dom";
 
 function AppContent() {
   const { room, gameStage, disconnectReason, connectionLogs, reconnect } = useGameContext();
@@ -18,7 +20,10 @@ function AppContent() {
   if (!isJoined) {
     screen = (
       <Container>
-        <LobbyScreen />
+        <Routes>
+          <Route path="/highscores" element={<HighScoresScreen />} />
+          <Route path="*" element={<LobbyScreen />} />
+        </Routes>
       </Container>
     );
   } else if (gameStage === "not_started") {

--- a/src/screens/HighScoresScreen.tsx
+++ b/src/screens/HighScoresScreen.tsx
@@ -1,0 +1,33 @@
+import { useEffect } from "react";
+import { Button, Stack, Title } from "@mantine/core";
+import { Link } from "react-router-dom";
+import { HighScore } from "../types";
+
+export default function HighScoresScreen() {
+  useEffect(() => {
+    const fetchScores = async () => {
+      try {
+        const wsUrl = import.meta.env.VITE_COLYSEUS_URL as string;
+        const httpUrl = wsUrl.replace(/^ws/, "http");
+        const res = await fetch(`${httpUrl.replace(/\/$/, "")}/highscores`);
+        if (res.ok) {
+          const data: HighScore[] = await res.json();
+          console.log("Highscores:", data);
+        }
+      } catch (err) {
+        console.error("Failed to fetch high scores", err);
+      }
+    };
+
+    fetchScores();
+  }, []);
+
+  return (
+    <Stack align="center" gap="lg" mt="xl">
+      <Title order={1}>High Scores</Title>
+      <Button component={Link} to="/" variant="light" size="lg">
+        Back to Lobby
+      </Button>
+    </Stack>
+  );
+}

--- a/src/screens/LobbyScreen.tsx
+++ b/src/screens/LobbyScreen.tsx
@@ -1,7 +1,7 @@
 import { Button, Divider, Group, Stack, TextInput, Title } from "@mantine/core";
 import { useState, useEffect } from "react";
 import { useGameContext } from "../hooks/GameProvider";
-import { useLocation } from "react-router-dom";
+import { useLocation, Link } from "react-router-dom";
 import { RoomList } from "../components/RoomList";
 
 export default function LobbyScreen() {
@@ -67,6 +67,10 @@ export default function LobbyScreen() {
       <Button size="lg" color="blue" onClick={handleCreate}>Create New Room</Button>
 
       <RoomList displayName={displayName} />
+
+      <Button component={Link} to="/highscores" size="lg" variant="light">
+        View High Scores
+      </Button>
     </Stack>
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,3 +99,12 @@ export interface GameState {
 
   historyPlayerStats: MapSchema<ColyseusPlayerHistory>;
 }
+
+export interface HighScore {
+  id: number;
+  createdAt: string;
+  players: string[];
+  undoUsed: boolean;
+  tasks: { displayName: string; player: string }[];
+  difficulty: number;
+}


### PR DESCRIPTION
## Summary
- define `HighScore` type
- add route to view high scores
- expose `HighScoresScreen`
- link high scores from lobby
- fetch highscores from backend (console.log for now)

## Testing
- `npm run build` *(fails: Cannot find module '@mantine/core' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68699e27a0f4832ca521aa07dab32cae