### PR TITLE
Add random highscore button

### DIFF
--- a/src/screens/HighScoresScreen.tsx
+++ b/src/screens/HighScoresScreen.tsx
@@ -4,27 +4,47 @@ import { Link } from "react-router-dom";
 import { HighScore } from "../types";
 
 export default function HighScoresScreen() {
-  useEffect(() => {
-    const fetchScores = async () => {
-      try {
-        const wsUrl = import.meta.env.VITE_COLYSEUS_URL as string;
-        const httpUrl = wsUrl.replace(/^ws/, "http");
-        const res = await fetch(`${httpUrl.replace(/\/$/, "")}/highscores`);
-        if (res.ok) {
-          const data: HighScore[] = await res.json();
-          console.log("Highscores:", data);
-        }
-      } catch (err) {
-        console.error("Failed to fetch high scores", err);
+  const fetchScores = async () => {
+    try {
+      const wsUrl = import.meta.env.VITE_COLYSEUS_URL as string;
+      const httpUrl = wsUrl.replace(/^ws/, "http");
+      const res = await fetch(`${httpUrl.replace(/\/$/, "")}/highscores`);
+      if (res.ok) {
+        const data: HighScore[] = await res.json();
+        console.log("Highscores:", data);
       }
-    };
+    } catch (err) {
+      console.error("Failed to fetch high scores", err);
+    }
+  };
 
+  const addRandomScore = async () => {
+    try {
+      const wsUrl = import.meta.env.VITE_COLYSEUS_URL as string;
+      const httpUrl = wsUrl.replace(/^ws/, "http");
+      const res = await fetch(`${httpUrl.replace(/\/$/, "")}/highscores/random`, {
+        method: "POST",
+      });
+      if (res.ok) {
+        const data: HighScore = await res.json();
+        console.log("Created random highscore:", data);
+        await fetchScores();
+      }
+    } catch (err) {
+      console.error("Failed to create random highscore", err);
+    }
+  };
+
+  useEffect(() => {
     fetchScores();
   }, []);
 
   return (
     <Stack align="center" gap="lg" mt="xl">
       <Title order={1}>High Scores</Title>
+      <Button onClick={addRandomScore} variant="light" size="lg">
+        Add Random Highscore
+      </Button>
       <Button component={Link} to="/" variant="light" size="lg">
         Back to Lobby
       </Button>


### PR DESCRIPTION
## Summary
- add API call to create a random highscore and refresh the list

## Testing
- `npm run build` *(fails: Cannot find module '@mantine/core' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6869a338b77c832cad62125f7058db5a