### PR TITLE
Fix reconnect modal close behavior

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ import DisconnectModal from "./components/DisconnectModal";
 import { Routes, Route } from "react-router-dom";
 
 function AppContent() {
-  const { room, gameStage, disconnectReason, connectionLogs, reconnect } = useGameContext();
+  const { room, gameStage, disconnectReason, connectionLogs, reconnect, clearDisconnectReason } = useGameContext();
   const isJoined = !!room;
 
   let screen;
@@ -48,6 +48,7 @@ function AppContent() {
         reason={disconnectReason}
         logs={connectionLogs}
         onReconnect={reconnect}
+        onClose={clearDisconnectReason}
       />
     </>
   );

--- a/src/components/DisconnectModal.tsx
+++ b/src/components/DisconnectModal.tsx
@@ -5,11 +5,12 @@ interface DisconnectModalProps {
   reason?: string | null;
   logs: string[];
   onReconnect: () => void;
+  onClose: () => void;
 }
 
-export default function DisconnectModal({ opened, reason, logs, onReconnect }: DisconnectModalProps) {
+export default function DisconnectModal({ opened, reason, logs, onReconnect, onClose }: DisconnectModalProps) {
   return (
-    <Modal opened={opened} onClose={() => {}} title="Connection Lost" centered closeOnClickOutside={false} closeOnEscape={false}>
+    <Modal opened={opened} onClose={onClose} title="Connection Lost" centered>
       <Stack>
         <Text c="red" fw={600}>Disconnected{reason ? `: ${reason}` : ''}</Text>
         {logs.length > 0 && (

--- a/src/hooks/useGameRoom.tsx
+++ b/src/hooks/useGameRoom.tsx
@@ -281,7 +281,14 @@ export const useGameRoom = (client: Colyseus.Client) => {
     room?.send("send_emoji", emoji);
   };
 
+  const clearDisconnectReason = () => setDisconnectReason(null);
+
   const reconnect = () => {
+    if (room) {
+      // If already connected just close the modal
+      setDisconnectReason(null);
+      return;
+    }
     const displayName = localStorage.getItem("displayName") || "";
     const roomId = localStorage.getItem("roomId") || "";
     if (displayName && roomId) {
@@ -326,6 +333,7 @@ export const useGameRoom = (client: Colyseus.Client) => {
     sendRestartGame,
     sendGiveUp,
     sendEmoji,
+    clearDisconnectReason,
     disconnectReason,
     connectionLogs,
     reconnect


### PR DESCRIPTION
## Summary
- allow the reconnect modal to be dismissed by clicking outside or the X
- prevent an unnecessary reconnect when already connected

## Testing
- `npm run build` *(fails: Cannot find module '@mantine/core')*

------
https://chatgpt.com/codex/tasks/task_e_6870bf98a82c832c959def723499da82