### PR TITLE
feat: add user settings store

### DIFF
--- a/src/hooks/useUserSettings.ts
+++ b/src/hooks/useUserSettings.ts
@@ -1,0 +1,22 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import type { UserSettings } from "../types";
+
+interface UserSettingsStore extends UserSettings {
+  setSetting: <K extends keyof UserSettings>(key: K, value: UserSettings[K]) => void;
+}
+
+export const useUserSettings = create<UserSettingsStore>()(
+  persist(
+    set => ({
+      confirmWhenPlayingCard: true,
+      setSetting: (key, value) =>
+        set(() => ({ [key]: value } as Partial<UserSettings>)),
+    }),
+    {
+      name: "user-settings",
+      storage: createJSONStorage(() => localStorage),
+    }
+  )
+);
+

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,3 +109,11 @@ export interface HighScore {
   tasks: { displayName: string; player: string, taskId: string, evaluationDescription: string, difficulty: number }[];
   difficulty: number;
 }
+
+// User settings
+
+export type SettingValue = boolean | string | number;
+
+export interface UserSettings {
+  confirmWhenPlayingCard: boolean;
+}


### PR DESCRIPTION
## Summary
- add basic user settings types
- create persisted zustand store with sample `confirmWhenPlayingCard` setting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba11d013c8832cae16d15cce542426