### PR TITLE
feat: add display and gameplay settings

### DIFF
--- a/src/components/GameCard.tsx
+++ b/src/components/GameCard.tsx
@@ -69,7 +69,7 @@ export const GameCard: React.FC<GameCardProps> = ({ card, size = 100, shadow = t
     opacity: faded ? 0.5 : 1,
   };
   
-  const shiftUp = size * 0.875 * (cardHoverScale - 1);
+  const shiftUp = size * 1.4 * 0.25;
   const cardHoverStyle: React.CSSProperties = {
     transform: `scale(${cardHoverScale}) translateY(-${shiftUp}px)`,
     filter: 'brightness(1.05)',

--- a/src/components/GameCard.tsx
+++ b/src/components/GameCard.tsx
@@ -7,6 +7,7 @@ import {
   IconRocket,
 } from '@tabler/icons-react';
 import { Card } from '../types';
+import { useUserSettings } from '../hooks/useUserSettings';
 
 interface GameCardProps {
   card: Card;
@@ -37,6 +38,7 @@ const iconMap = {
 
 export const GameCard: React.FC<GameCardProps> = ({ card, size = 100, shadow = true, onClick, disabled, showHoverAnimation, faded }) => {
   const { color, number } = card;
+  const cardHoverScale = useUserSettings(s => s.cardHoverScale);
   const { background, dark } = colorStyles[color];
   const IconComponent = iconMap[color];
   const height = size *  1.4; // Aspect ratio 5:7 for cards
@@ -67,9 +69,9 @@ export const GameCard: React.FC<GameCardProps> = ({ card, size = 100, shadow = t
     opacity: faded ? 0.5 : 1,
   };
   
-  const shiftUp = size * 1.4 * 0.25; // 25% of height
+  const shiftUp = size * 0.875 * (cardHoverScale - 1);
   const cardHoverStyle: React.CSSProperties = {
-    transform: `scale(1.4) translateY(-${shiftUp}px)`,
+    transform: `scale(${cardHoverScale}) translateY(-${shiftUp}px)`,
     filter: 'brightness(1.05)',
   };
 

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,5 +1,5 @@
 // components/SettingsModal.tsx
-import { Modal, Stack, Text, Divider, Switch, NumberInput } from '@mantine/core';
+import { Modal, Stack, Text, Divider, Switch, Slider } from '@mantine/core';
 import { useUserSettings } from '../hooks/useUserSettings';
 
 export interface SettingsModalProps {
@@ -8,53 +8,101 @@ export interface SettingsModalProps {
 }
 
 export function SettingsModal({ opened, onClose }: SettingsModalProps) {
-  const confirmWhenPlayingCard = useUserSettings(s => s.confirmWhenPlayingCard);
-  const cardHoverScale = useUserSettings(s => s.cardHoverScale);
-  const showReactionPanel = useUserSettings(s => s.showReactionPanel);
-  const handCardSize = useUserSettings(s => s.handCardSize);
-  const communicateCardSize = useUserSettings(s => s.communicateCardSize);
-  const setSetting = useUserSettings(s => s.setSetting);
+  const confirmWhenPlayingCard = useUserSettings((s) => s.confirmWhenPlayingCard);
+  const cardHoverScale = useUserSettings((s) => s.cardHoverScale);
+  const showReactionPanel = useUserSettings((s) => s.showReactionPanel);
+  const handCardSize = useUserSettings((s) => s.handCardSize);
+  const communicateCardSize = useUserSettings((s) => s.communicateCardSize);
+  const setSetting = useUserSettings((s) => s.setSetting);
 
   return (
-    <Modal opened={opened} onClose={onClose} title="Settings" centered>
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title="Settings"
+      centered
+    >
       <Stack gap="sm">
         <Text fw={700}>Gameplay</Text>
+
         <Switch
           checked={confirmWhenPlayingCard}
           onChange={(e) => setSetting('confirmWhenPlayingCard', e.currentTarget.checked)}
           label="Confirm before playing a card"
           aria-label="Confirm before playing a card"
         />
+
         <Divider />
 
         <Text fw={700}>Display</Text>
-        <NumberInput
-          label="Card hover scale"
-          value={cardHoverScale}
-          onChange={(v) => setSetting('cardHoverScale', Number(v) || 1.2)}
-          min={1}
-          max={2}
-          step={0.1}
-        />
+
+        {/* Card hover scale */}
+        <Stack gap={2}>
+          <Text size="md" fw={500}>
+            Card hover scale: {cardHoverScale?.toFixed(2)}×
+          </Text>
+          <Slider
+            size="md"
+            value={cardHoverScale ?? 1.2}
+            onChange={(v) => setSetting('cardHoverScale', v)}
+            min={1}
+            max={2}
+            step={0.05}
+            aria-label="Card hover scale"
+            // ticks only, no text labels to avoid overlap
+            marks={[{ value: 1 }, { value: 1.2 }, { value: 1.5 }, { value: 2 }]}
+            mt={4}
+            mb="sm"
+          />
+        </Stack>
+
+        {/* Hand card size */}
+        <Stack gap={2}>
+          <Text size="md" fw={500}>
+            Hand card size: {handCardSize}px
+          </Text>
+          <Slider
+            size="md"
+            value={handCardSize ?? 120}
+            onChange={(v) => setSetting('handCardSize', v)}
+            min={80}
+            max={200}
+            step={1}
+            aria-label="Hand card size"
+            marks={[{ value: 80 }, { value: 120 }, { value: 160 }, { value: 200 }]}
+            mt={4}
+            mb="sm"
+          />
+        </Stack>
+
+        {/* Communicated card size */}
+        <Stack gap={2}>
+          <Text size="md" fw={500}>
+            Communicated card size: {communicateCardSize}px
+          </Text>
+          <Slider
+            size="md"
+            value={communicateCardSize ?? 80}
+            onChange={(v) => setSetting('communicateCardSize', v)}
+            min={60}
+            max={160}
+            step={1}
+            aria-label="Communicated card size"
+            marks={[{ value: 60 }, { value: 100 }, { value: 130 }, { value: 160 }]}
+            mt={4}
+            mb="sm"
+          />
+        </Stack>
+
+        <Divider />
+
+        {/* Move this to the end as requested */}
         <Switch
+          size="md"
           checked={showReactionPanel}
           onChange={(e) => setSetting('showReactionPanel', e.currentTarget.checked)}
           label="Show reaction panel"
           aria-label="Show reaction panel"
-        />
-        <NumberInput
-          label="Hand card size"
-          value={handCardSize}
-          onChange={(v) => setSetting('handCardSize', Number(v) || 120)}
-          min={80}
-          max={200}
-        />
-        <NumberInput
-          label="Communicated card size"
-          value={communicateCardSize}
-          onChange={(v) => setSetting('communicateCardSize', Number(v) || 80)}
-          min={60}
-          max={160}
         />
       </Stack>
     </Modal>

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,5 +1,5 @@
 // components/SettingsModal.tsx
-import { Modal, Stack, Text, Divider, Switch } from '@mantine/core';
+import { Modal, Stack, Text, Divider, Switch, NumberInput } from '@mantine/core';
 import { useUserSettings } from '../hooks/useUserSettings';
 
 export interface SettingsModalProps {
@@ -9,6 +9,10 @@ export interface SettingsModalProps {
 
 export function SettingsModal({ opened, onClose }: SettingsModalProps) {
   const confirmWhenPlayingCard = useUserSettings(s => s.confirmWhenPlayingCard);
+  const cardHoverScale = useUserSettings(s => s.cardHoverScale);
+  const showReactionPanel = useUserSettings(s => s.showReactionPanel);
+  const handCardSize = useUserSettings(s => s.handCardSize);
+  const communicateCardSize = useUserSettings(s => s.communicateCardSize);
   const setSetting = useUserSettings(s => s.setSetting);
 
   return (
@@ -23,10 +27,35 @@ export function SettingsModal({ opened, onClose }: SettingsModalProps) {
         />
         <Divider />
 
-        {/* Future settings go here
         <Text fw={700}>Display</Text>
-        <Switch label="Show card hints" />
-        */}
+        <NumberInput
+          label="Card hover scale"
+          value={cardHoverScale}
+          onChange={(v) => setSetting('cardHoverScale', Number(v) || 1.2)}
+          min={1}
+          max={2}
+          step={0.1}
+        />
+        <Switch
+          checked={showReactionPanel}
+          onChange={(e) => setSetting('showReactionPanel', e.currentTarget.checked)}
+          label="Show reaction panel"
+          aria-label="Show reaction panel"
+        />
+        <NumberInput
+          label="Hand card size"
+          value={handCardSize}
+          onChange={(v) => setSetting('handCardSize', Number(v) || 120)}
+          min={80}
+          max={200}
+        />
+        <NumberInput
+          label="Communicated card size"
+          value={communicateCardSize}
+          onChange={(v) => setSetting('communicateCardSize', Number(v) || 80)}
+          min={60}
+          max={160}
+        />
       </Stack>
     </Modal>
   );

--- a/src/hooks/useUserSettings.ts
+++ b/src/hooks/useUserSettings.ts
@@ -10,6 +10,10 @@ export const useUserSettings = create<UserSettingsStore>()(
   persist(
     set => ({
       confirmWhenPlayingCard: false,
+      cardHoverScale: 1.2,
+      showReactionPanel: true,
+      handCardSize: 120,
+      communicateCardSize: 80,
       setSetting: (key, value) =>
         set(() => ({ [key]: value } as Partial<UserSettings>)),
     }),

--- a/src/screens/PlayerGridLayout.tsx
+++ b/src/screens/PlayerGridLayout.tsx
@@ -61,6 +61,9 @@ export default function PlayerGridLayout({ gridTemplateAreas, children, isMyTurn
   const [infoOpened, { open: openInfo, close: closeInfo }] = useDisclosure(false);
   const [settingsOpened, { open: openSettings, close: closeSettings }] = useDisclosure(false);
   const confirmWhenPlayingCard = useUserSettings(s => s.confirmWhenPlayingCard);
+  const showReactionPanel = useUserSettings(s => s.showReactionPanel);
+  const handCardSize = useUserSettings(s => s.handCardSize);
+  const communicateCardSize = useUserSettings(s => s.communicateCardSize);
   
   if (!activePlayer || !room || !playerOrder.length) return null;
 
@@ -125,7 +128,7 @@ export default function PlayerGridLayout({ gridTemplateAreas, children, isMyTurn
             <PlayerStatus
               player={player}
               assignedTasks={assignedTasks}
-              communicateWidth={80}
+              communicateWidth={communicateCardSize}
               taskSize="md"
               textSize="xl"
               isCommander={commanderPlayer === player.sessionId}
@@ -138,7 +141,7 @@ export default function PlayerGridLayout({ gridTemplateAreas, children, isMyTurn
       <Center style={{ gridArea: "active-comm" }}>
       <CommunicatedCard
         player={activePlayer}
-        width={80}
+        width={communicateCardSize}
         onClick={() => {
           // Only allow if stage is trick_start or trick_end AND not already communicated
           const canCommunicate =
@@ -199,7 +202,7 @@ export default function PlayerGridLayout({ gridTemplateAreas, children, isMyTurn
 
         <GameHand
           hand={hand}
-          cardWidth={120}
+          cardWidth={handCardSize}
           overlap
           disabled={(!isMyTurn || someoneCommunicating) && !communicateMode}
           onCardClick={(card) => {
@@ -226,7 +229,9 @@ export default function PlayerGridLayout({ gridTemplateAreas, children, isMyTurn
         />
       </Box>
       {/* Emoji Send Panel */}
-      <Box style={{ gridArea: "emoji-send" }}><EmojiSendPanel /></Box>
+      {showReactionPanel && (
+        <Box style={{ gridArea: "emoji-send" }}><EmojiSendPanel /></Box>
+      )}
 
 
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,4 +116,8 @@ export type SettingValue = boolean | string | number;
 
 export interface UserSettings {
   confirmWhenPlayingCard: boolean;
+  cardHoverScale: number;
+  showReactionPanel: boolean;
+  handCardSize: number;
+  communicateCardSize: number;
 }


### PR DESCRIPTION
## Summary
- expand user settings store with card hover scale, reaction panel toggle, and card size controls
- expose new settings in SettingsModal for display customization
- apply settings to card hover effect, player hand, communicated cards, and reaction panel visibility

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba1f0f9c5c832cbf39b5dfa1f537d1